### PR TITLE
Fix cmake complaining about apriltag::apriltag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(include)
 
 add_library(AprilTagNode SHARED src/AprilTagNode.cpp)
 ament_target_dependencies(AprilTagNode rclcpp rclcpp_components sensor_msgs apriltag_msgs tf2_msgs image_transport cv_bridge)
-target_link_libraries(AprilTagNode apriltag::apriltag)
+target_link_libraries(AprilTagNode apriltag)
 rclcpp_components_register_nodes(AprilTagNode "AprilTagNode")
 
 ament_environment_hooks(${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH})


### PR DESCRIPTION
Can't build on Ubuntu 20.04 because cmake keeps running into an error when trying to compile:

```
CMake Error at CMakeLists.txt:24 (add_library):
Target "AprilTagNode" links to target "apriltag::apriltag" but the target
was not found.  Perhaps a find_package() call is missing for an IMPORTED
target, or an ALIAS target is missing?
```

@christianrauch not sure why you had the namespace `apriltag::` recently, but besides trying to compile on my local Ubuntu 20.04 I also tested compiling on a clean docker container with `docker run -it ros:foxy-ros-core` and the same error occurs. Removing the namespace fixes the issue and allows the package to be compiled.

Feel free to close the PR if it turns out to be an error on my end.