### PR TITLE
fixed bugs, so that it works with ros2 galaxy

### DIFF
--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -62,8 +62,8 @@ AprilTagNode::AprilTagNode(rclcpp::NodeOptions options)
     td->refine_edges =  declare_parameter<int>("refine-edges", true);
 
     // get tag names, IDs and sizes
-    const auto ids = declare_parameter<std::vector<int64_t>>("tag_ids", {});
-    const auto frames = declare_parameter<std::vector<std::string>>("tag_frames", {});
+    const auto ids = declare_parameter<std::vector<int64_t>>("tag_ids", std::vector<int64_t>{});
+    const auto frames = declare_parameter<std::vector<std::string>>("tag_frames", std::vector<std::string>{});
 
     if(!frames.empty()) {
         if(ids.size()!=frames.size()) {
@@ -72,7 +72,7 @@ AprilTagNode::AprilTagNode(rclcpp::NodeOptions options)
         for(size_t i = 0; i<ids.size(); i++) { tag_frames[ids[i]] = frames[i]; }
     }
 
-    const auto sizes = declare_parameter<std::vector<double>>("tag_sizes", {});
+    const auto sizes = declare_parameter<std::vector<double>>("tag_sizes", std::vector<double>{});
     if(!sizes.empty()) {
         // use tag specific size
         if(ids.size()!=sizes.size()) {


### PR DESCRIPTION
galaxy / rolling changed the API for param loading.  You can't have {}, you have to have a to use type{}

Otherwise there is a build error.