### PR TITLE
fixed doubled tag size for solve_pnp

### DIFF
--- a/src/homography_to_pose.cpp
+++ b/src/homography_to_pose.cpp
@@ -95,10 +95,11 @@ estim_pose_f apriltag_homography = [](apriltag_detection_t* const detection, con
 
 estim_pose_f solve_pnp = [](apriltag_detection_t* const detection, const Mat3& P, double tagsize) -> geometry_msgs::msg::Transform {
     std::vector<cv::Point3d> objectPoints;
-    objectPoints.emplace_back(-tagsize, -tagsize, 0);
-    objectPoints.emplace_back(+tagsize, -tagsize, 0);
-    objectPoints.emplace_back(+tagsize, +tagsize, 0);
-    objectPoints.emplace_back(-tagsize, +tagsize, 0);
+    const double half_tagsize = 0.5 * tagsize;
+    objectPoints.emplace_back(-half_tagsize, -half_tagsize, 0);
+    objectPoints.emplace_back(+half_tagsize, -half_tagsize, 0);
+    objectPoints.emplace_back(+half_tagsize, +half_tagsize, 0);
+    objectPoints.emplace_back(-half_tagsize, +half_tagsize, 0);
 
     std::vector<cv::Point2d> imagePoints;
     double tag_x[4] = {-1, 1, 1, -1};


### PR DESCRIPTION
Set the object points to +/- half the tag size, so that the resulting object points represent a rectangle with an edge length that equals the defined tag size.