### PR TITLE
Change True/False strings in cfg yaml

### DIFF
--- a/cfg/tags_36h11.yaml
+++ b/cfg/tags_36h11.yaml
@@ -10,9 +10,9 @@
             threads: 1          # number of threads
             decimate: 2.0       # decimate resolution for quad detection
             blur: 0.0           # sigma of Gaussian blur for quad detection
-            refine: 1           # snap to strong gradients
+            refine: True        # snap to strong gradients
             sharpening: 0.25    # sharpening of decoded images
-            debug: 0            # write additional debugging images to current working directory
+            debug: False        # write additional debugging images to current working directory
 
         # optional list of tags
         tag:


### PR DESCRIPTION
Under ROS Humble, and the latest installed version from April repo, the launch file fails by inability to convert {int} to {bool}. 

This resolved the issue.
---
1 - is treated  as int
"True" - is treated as string
True - as treated as bool