### PR TITLE
fix orientation of tag frame estimated by homography method

### DIFF
--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -14,6 +14,14 @@ homography(apriltag_detection_t* const detection, const std::array<double, 4>& i
     apriltag_pose_t pose;
     estimate_pose_for_tag_homography(&info, &pose);
 
+    // rotate frame such that z points in the opposite direction towards the camera
+    for(int i = 0; i < 3; i++) {
+        // swap x and y axes
+        std::swap(MATD_EL(pose.R, 0, i), MATD_EL(pose.R, 1, i));
+        // invert z axis
+        MATD_EL(pose.R, 2, i) *= -1;
+    }
+
     return tf2::toMsg<apriltag_pose_t, geometry_msgs::msg::Transform>(const_cast<const apriltag_pose_t&>(pose));
 }
 


### PR DESCRIPTION
Fixes #37 .

Frame comparison for the same input sequence:

| pnp | homography |
| - | - |
| <video src="https://github.com/christianrauch/apriltag_ros/assets/8573621/02018c73-4a02-48cd-aab3-22881c3d9338"> | <video src="https://github.com/christianrauch/apriltag_ros/assets/8573621/c12eb212-374b-4252-87d4-5635ea14267a"> |


