### PR TITLE
fix launch file topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AprilTag ROS2 Node
+# AprilTag ROS 2 Node
 
-This ROS2 node uses the AprilTag library to detect AprilTags in images and publish their pose, id and additional metadata.
+This ROS 2 node uses the AprilTag library to detect AprilTags in images and publish their pose, id and additional metadata.
 
 For more information on AprilTag, the paper and the reference implementation: https://april.eecs.umich.edu/software/apriltag.html
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ apriltag_ros
   AprilTagNode
 ```
 
-This `AprilTagNode` component can be loaded with other nodes into a "container node" process where they used shared-memory communication to prevent unnecessary data copies. The example launch file [v4l2_36h11.launch.yml](launch/v4l2_36h11.launch.yml) loads the `AprilTagNode` component together with the `v4l2_camera::V4L2Camera` component from the [`v4l2_camera` package](https://gitlab.com/boldhearts/ros2_v4l2_camera) (`sudo apt install ros-$ROS_DISTRO-v4l2-camera`) into one container and enables `use_intra_process_comms` for both:
+This `AprilTagNode` component can be loaded with other nodes into a "container node" process where they used shared-memory communication to prevent unnecessary data copies. The example launch file [camera_36h11.launch.yml](launch/camera_36h11.launch.yml) loads the `AprilTagNode` component together with the `camera::CameraNode` component from the [`camera_ros` package](https://index.ros.org/p/camera_ros/) (`sudo apt install ros-$ROS_DISTRO-camera-ros`) into one container and enables `use_intra_process_comms` for both:
 ```sh
-ros2 launch apriltag_ros v4l2_36h11.launch.yml
+ros2 launch apriltag_ros camera_36h11.launch.yml
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ apriltag:                 # node name
       sharpening: 0.25    # sharpening of decoded images
       debug: 0            # write additional debugging images to current working directory
 
+    pose_estimation_method: "pnp" # method for estimating the tag pose
+
     # (optional) list of tags
     # If defined, 'frames' and 'sizes' must have the same length as 'ids'.
     tag:

--- a/cfg/tags_36h11.yaml
+++ b/cfg/tags_36h11.yaml
@@ -14,6 +14,9 @@
             sharpening: 0.25    # sharpening of decoded images
             debug: False        # write additional debugging images to current working directory
 
+
+        pose_estimation_method: "pnp"   # method for estimating the tag pose
+
         # optional list of tags
         tag:
             ids: [9, 14]            # tag ID

--- a/launch/camera_36h11.launch.yml
+++ b/launch/camera_36h11.launch.yml
@@ -9,13 +9,13 @@ launch:
     name: apriltag_container
     namespace: ""
     composable_node:
-    - pkg: v4l2_camera
-      plugin: v4l2_camera::V4L2Camera
+    - pkg: camera_ros
+      plugin: camera::CameraNode
       name: camera
-      namespace: v4l2
+      namespace: camera
       param:
-      - name: video_device
-        value: /dev/video$(var device)
+      - name: camera
+        value: $(var device)
       extra_arg:
       - name: use_intra_process_comms
         value: "True"
@@ -23,10 +23,12 @@ launch:
     - pkg: image_proc
       plugin: image_proc::RectifyNode
       name: rectify
-      namespace: v4l2
+      namespace: camera
       remap:
       - from: image
-        to: image_raw
+        to: /camera/camera/image_raw
+      - from: camera_info
+        to: /camera/camera/camera_info
       extra_arg:
       - name: use_intra_process_comms
         value: "True"
@@ -37,9 +39,9 @@ launch:
       namespace: apriltag
       remap:
       - from: /apriltag/image_rect
-        to: /v4l2/image_rect
-      - from: /apriltag/camera_info
-        to: /v4l2/camera_info
+        to: /camera/image_rect
+      - from: /camera/camera_info
+        to: /camera/camera/camera_info
       param:
       - from: $(find-pkg-share apriltag_ros)/cfg/tags_36h11.yaml
       extra_arg:

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>image_transport</depend>
   <depend>cv_bridge</depend>
 
+  <exec_depend>camera_ros</exec_depend>
   <exec_depend>image_proc</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,8 @@
   <depend>image_transport</depend>
   <depend>cv_bridge</depend>
 
+  <exec_depend>image_proc</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>


### PR DESCRIPTION
Fix the topic remapping in the launch file and replace `v4l2_camera::V4L2Camera` with `camera::CameraNode` for full libcamera support, including the Raspberry Pi cameras.

Also add a check for valid camera intrinsics on the `camera_info` topic.

