### PR TITLE
Add image_transport_plugins

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
 
   <exec_depend>camera_ros</exec_depend>
   <exec_depend condition="$ROS_DISTRO != 'humble'">image_proc</exec_depend>
+  <exec_depend>image_transport_plugins</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>


### PR DESCRIPTION
This package is required for compressed image transport, otherwise it throws:

```bash
[apriltag_node-5] terminate called after throwing an instance of 'image_transport::TransportLoadException'
[apriltag_node-5] what(): Unable to load plugin for transport 'image_transport/compressed_sub', error string:
[apriltag_node-5] According to the loaded plugin descriptions the class image_transport/compressed_sub with base class type image_transport::SubscriberPlugin does not exist. Declared types are image_transport/raw_sub
```