### PR TITLE
Added optional debug image to visualize april tag detection overlaid …

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The node subscribes via a `image_transport::CameraSubscriber` to rectified image
 ### Publisher:
 - `/tf` (type: `tf2_msgs/msg/TFMessage`)
 - `detections` (type: `apriltag_msgs/msg/AprilTagDetectionArray`)
+- `detections_image` (type: `sensor_msgs/msg/Image`) 
 
 The camera intrinsics `P` in `CameraInfo` are used to compute the marker tag pose `T` from the homography `H`. The image and the camera intrinsics need to have the same timestamp.
 
@@ -46,6 +47,8 @@ apriltag:                 # node name
 
     pose_estimation_method: "pnp" # method for estimating the tag pose
 
+    debug_image_pub: false  # Publish debug image showing detection results
+
     # (optional) list of tags
     # If defined, 'frames' and 'sizes' must have the same length as 'ids'.
     tag:
@@ -57,6 +60,8 @@ apriltag:                 # node name
 The `family` (string) defines the tag family for the detector and must be one of `16h5`, `25h9`, `36h11`, `Circle21h7`, `Circle49h12`, `Custom48h12`, `Standard41h12`, `Standard52h13`. `size` (float) is the tag edge size in meters, assuming square markers.
 
 Instead of publishing all tag poses, the list `tag.ids` can be used to only publish selected tag IDs. Each tag can have an associated child frame name in `tag.frames` and a tag specific size in `tag.sizes`. These lists must either have the same length as `tag.ids` or may be empty. In this case, a default frame name of the form `tag<family>:<id>` and the default tag edge size `size` will be used.
+
+To visualize the april tags overlaid on the original input image, set `debug_image_pub` to true. This is disabled by default.
 
 The remaining parameters are set to the their default values from the library. See `apriltag.h` for a more detailed description of their function.
 

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -75,11 +75,13 @@ private:
     std::atomic<bool> profile;
     std::unordered_map<int, std::string> tag_frames;
     std::unordered_map<int, double> tag_sizes;
+    bool debug_image_pub;
 
     std::function<void(apriltag_family_t*)> tf_destructor;
 
     const image_transport::CameraSubscriber sub_cam;
     const rclcpp::Publisher<apriltag_msgs::msg::AprilTagDetectionArray>::SharedPtr pub_detections;
+    const rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr detections_image_pub;
     tf2_ros::TransformBroadcaster tf_broadcaster;
 
     pose_estimation_f estimate_pose = nullptr;
@@ -105,6 +107,7 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
         declare_parameter("image_transport", "raw", descr({}, true)),
         rmw_qos_profile_sensor_data)),
     pub_detections(create_publisher<apriltag_msgs::msg::AprilTagDetectionArray>("detections", rclcpp::QoS(1))),
+    detections_image_pub(create_publisher<sensor_msgs::msg::Image>("detections_image", rclcpp::QoS(1))),
     tf_broadcaster(this)
 {
     // read-only parameters
@@ -142,6 +145,7 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
 
     declare_parameter("max_hamming", 0, descr("reject detections with more corrected bits than allowed"));
     declare_parameter("profile", false, descr("print profiling information to stdout"));
+    declare_parameter("debug_image_pub", false, descr("Publish debug image showing detection results"));
 
     if(!frames.empty()) {
         if(ids.size() != frames.size()) {
@@ -206,6 +210,12 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
 
     std::vector<geometry_msgs::msg::TransformStamped> tfs;
 
+    // Create a colored image for use in debug image
+    cv::Mat img_color;
+    if (debug_image_pub) {
+        cv::cvtColor(img_uint8, img_color, cv::COLOR_GRAY2BGR);
+    }
+
     for(int i = 0; i < zarray_size(detections); i++) {
         apriltag_detection_t* det;
         zarray_get(detections, i, &det);
@@ -233,6 +243,23 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
         std::memcpy(msg_detection.homography.data(), det->H->data, sizeof(double) * 9);
         msg_detections.detections.push_back(msg_detection);
 
+        if (debug_image_pub){
+            // Draw outline
+            for(size_t j = 0; j < msg_detection.corners.size(); j++) {
+                cv::Point2f p1(msg_detection.corners[j].x, msg_detection.corners[j].y);
+                cv::Point2f p2(msg_detection.corners[(j + 1) % msg_detection.corners.size()].x,
+                            msg_detection.corners[(j + 1) % msg_detection.corners.size()].y);
+                // Change color for each index of i
+                cv::line(img_color, p1, p2, cv::Scalar(0, 255, 0), 3);
+            }
+
+            // Write tag ID at the center
+            cv::putText(
+                img_color, std::to_string(msg_detection.id),
+                cv::Point2f(msg_detection.centre.x - 10, msg_detection.centre.y + 10),
+                cv::FONT_HERSHEY_SIMPLEX, 1, cv::Scalar(0, 0, 255), 3);
+        }
+         
         // 3D orientation and position
         if(estimate_pose != nullptr && calibrated) {
             geometry_msgs::msg::TransformStamped tf;
@@ -243,6 +270,12 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
             tf.transform = estimate_pose(det, intrinsics, size);
             tfs.push_back(tf);
         }
+    }
+
+    if (debug_image_pub){
+        // Write cv mat image back into image message and publish
+        sensor_msgs::msg::Image::SharedPtr img_msg = cv_bridge::CvImage(msg_img->header, "bgr8", img_color).toImageMsg();
+        detections_image_pub->publish(*img_msg);
     }
 
     pub_detections->publish(msg_detections);
@@ -271,6 +304,7 @@ AprilTagNode::onParameter(const std::vector<rclcpp::Parameter>& parameters)
         IF("detector.debug", td->debug)
         IF("max_hamming", max_hamming)
         IF("profile", profile)
+        IF("debug_image_pub", debug_image_pub)
     }
 
     mutex.unlock();


### PR DESCRIPTION
Added optional debug image publisher to help visualize april tag detentions over laid on the input image. Published on the topic `detections_image`, publishing this topic can be enabled/disabled by the parameter `debug_image_pub`. Each april tag is boxed in green and labeled with the detected tag ID.

<img width="617" height="647" alt="image" src="https://github.com/user-attachments/assets/8e08b128-c8fa-4c3a-8f0d-c7072e6178f7" />
